### PR TITLE
fix: dropout naming

### DIFF
--- a/momentfm/models/layers/embed.py
+++ b/momentfm/models/layers/embed.py
@@ -131,7 +131,7 @@ class TimeFeatureEmbedding(nn.Module):
 
 class DataEmbedding(nn.Module):
     def __init__(
-        self, c_in, d_model, model_name, embed_type="fixed", freq="h", dropout=0.1
+        self, c_in, d_model, model_name, embed_type="fixed", freq="h", patch_dropout=0.1
     ):
         super(DataEmbedding, self).__init__()
         self.value_embedding = TokenEmbedding(c_in=c_in, d_model=d_model)
@@ -143,7 +143,7 @@ class DataEmbedding(nn.Module):
             if embed_type != "timeF"
             else TimeFeatureEmbedding(d_model=d_model, embed_type=embed_type, freq=freq)
         )
-        self.dropout = nn.Dropout(p=dropout)
+        self.dropout = nn.Dropout(p=patch_dropout)
 
     def forward(self, x, x_mark=None):
         if x_mark is None:
@@ -158,7 +158,7 @@ class DataEmbedding(nn.Module):
 
 
 class DataEmbedding_wo_pos(nn.Module):
-    def __init__(self, c_in, d_model, embed_type="fixed", freq="h", dropout=0.1):
+    def __init__(self, c_in, d_model, embed_type="fixed", freq="h", patch_dropout=0.1):
         super(DataEmbedding_wo_pos, self).__init__()
 
         self.value_embedding = TokenEmbedding(c_in=c_in, d_model=d_model)
@@ -168,7 +168,7 @@ class DataEmbedding_wo_pos(nn.Module):
             if embed_type != "timeF"
             else TimeFeatureEmbedding(d_model=d_model, embed_type=embed_type, freq=freq)
         )
-        self.dropout = nn.Dropout(p=dropout)
+        self.dropout = nn.Dropout(p=patch_dropout)
 
     def forward(self, x, x_mark):
         if x_mark is None:
@@ -185,7 +185,7 @@ class PatchEmbedding(nn.Module):
         seq_len: int = 512,
         patch_len: int = 8,
         stride: int = 8,
-        dropout: int = 0.1,
+        patch_dropout: int = 0.1,
         add_positional_embedding: bool = False,
         value_embedding_bias: bool = False,
         orth_gain: float = 1.41,
@@ -211,7 +211,7 @@ class PatchEmbedding(nn.Module):
             self.position_embedding = PositionalEmbedding(d_model)
 
         # Residual dropout
-        self.dropout = nn.Dropout(dropout)
+        self.dropout = nn.Dropout(patch_dropout)
 
     def forward(self, x: torch.Tensor, mask: torch.Tensor = None) -> torch.Tensor:
         mask = Masking.convert_seq_to_patch_view(

--- a/momentfm/models/moment.py
+++ b/momentfm/models/moment.py
@@ -113,7 +113,7 @@ class MOMENT(nn.Module):
             seq_len=config.seq_len,
             patch_len=config.patch_len,
             stride=config.patch_stride_len,
-            dropout=config.getattr("dropout", 0.1),
+            patch_dropout=config.getattr("patch_dropout", 0.1),
             add_positional_embedding=config.getattr("add_positional_embedding", True),
             value_embedding_bias=config.getattr("value_embedding_bias", False),
             orth_gain=config.getattr("orth_gain", 1.41),
@@ -174,7 +174,7 @@ class MOMENT(nn.Module):
             return PretrainHead(
                 self.config.d_model,
                 self.config.patch_len,
-                self.config.getattr("dropout", 0.1),
+                self.config.getattr("head_dropout", 0.1),
                 self.config.getattr("orth_gain", 1.41),
             )
         elif task_name == TASKS.CLASSIFICATION:
@@ -182,7 +182,7 @@ class MOMENT(nn.Module):
                 self.config.n_channels,
                 self.config.d_model,
                 self.config.num_class,
-                self.config.getattr("dropout", 0.1),
+                self.config.getattr("head_dropout", 0.1),
                 reduction = self.config.getattr("reduction", "concat"),
             )
         elif task_name == TASKS.FORECASTING:


### PR DESCRIPTION
- tested the model loading for forecasting, classification, imputation and representation learning
- because the dropout is not set in the HF config, the naming correction did not break anything
- all the dropouts are set to the default values specified in the model implementation, no dropout is set from the config directly (besides the t5 one, but it is well-separated inside the t5 config)