### PR TITLE
Bump transformers dependency to 4.36.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ dependencies = [
   "huggingface-hub==0.24.0",
   "numpy==1.25.2",
   "torch~=2.0",              # package was tested on 2.0.1
-  "transformers==4.33.3",
+  "transformers==4.36.0",
 ]
 
 requires-python = ">=3.10"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "momentfm"
-version = "0.1.3"
+version = "0.1.5"
 dependencies = [
   "huggingface-hub==0.24.0",
   "numpy==1.25.2",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 huggingface-hub==0.24.0
 numpy==1.25.2
 torch==2.0.1
-transformers==4.33.3
+transformers==4.36.0

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,7 @@ with open("requirements.txt") as f:
 
 setup(
     name="momentfm",
-    version="0.1.2",
+    version="0.1.5",
     description="MOMENT: A Family of Open Time-series Foundation Models",
     author="Mononito Goswami, Konrad Szafer, Arjun Choudhry, Yifu Cai, Shuo Li, Artur Dubrawski",
     author_email="mgoswami@andrew.cmu.edu",


### PR DESCRIPTION
Bump transformers version to 4.36.0, which is needed to address this vulnerability: https://security.snyk.io/vuln/SNYK-PYTHON-TRANSFORMERS-6135747

`from transformers import T5Config, T5EncoderModel, T5Model`
Seems the T5 API did not change from 4.33.3 to 4.36.0. Would be great to add some form of smoke or validation test in this repository to support better change management practices moving forward.