### PR TITLE
Add GitHub Actions CI testing numpy 1.x + 2.x and transformers 4.x + 5.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,71 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  test:
+    name: py${{ matrix.python-version }} · numpy${{ matrix.numpy-spec }} · tx${{ matrix.transformers-spec }}
+    runs-on: ubuntu-latest
+
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          # Baseline: the pyproject lower bounds.
+          - python-version: "3.10"
+            numpy-spec: "==1.26.4"
+            transformers-spec: "==4.54.1"
+            torch-spec: "==2.0.1"
+
+          # Mid-range: a popular interim version.
+          - python-version: "3.11"
+            numpy-spec: "==1.26.4"
+            transformers-spec: ">=4.54.1,<5.0"
+            torch-spec: ">=2.0.1"
+
+          # Frontier: numpy 2.x + transformers 5.x.
+          # This is the matrix entry that, if green, unblocks a pypi
+          # release. It is the load-bearing one for downstream users
+          # who have already moved to numpy 2.x.
+          - python-version: "3.12"
+            numpy-spec: ">=2.0"
+            transformers-spec: ">=5.0"
+            torch-spec: ">=2.4"
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+          cache: pip
+
+      - name: Upgrade pip
+        run: python -m pip install --upgrade pip
+
+      - name: Install matrix-pinned core dependencies
+        run: |
+          pip install "numpy${{ matrix.numpy-spec }}"
+          pip install "torch${{ matrix.torch-spec }}" --index-url https://download.pytorch.org/whl/cpu
+          pip install "transformers${{ matrix.transformers-spec }}"
+
+      - name: Install momentfm from source
+        run: pip install -e .
+
+      - name: Install dev dependencies
+        run: pip install pytest
+
+      - name: Import smoke
+        run: |
+          python -c "import momentfm; print('momentfm import OK')"
+          python -c "from momentfm import MOMENTPipeline; print('MOMENTPipeline import OK')"
+          python -c "from momentfm import MOMENT; print('MOMENT import OK')"
+
+      - name: Run pytest
+        run: pytest -v --tb=short


### PR DESCRIPTION
This PR adds a CI workflow that tests momentfm against three dependency combinations on every push:

| Cell | python | numpy | transformers | torch |
|---|---|---|---|---|
| Lower bound | 3.10 | ==1.26.4 | ==4.54.1 | ==2.0.1 |
| Mid-range | 3.11 | ==1.26.4 | >=4.54.1,<5.0 | >=2.0.1 |
| Frontier | 3.12 | >=2.0 | >=5.0 | >=2.4 |

The frontier cell is the load-bearing one for any downstream user who has already migrated to numpy 2.x. Today the PyPI release `v0.1.4` strictly pins `numpy==1.25.2` and `transformers==4.33.3` and so silently breaks in numpy-2 environments. `main` already has the loose pins (PR #81), but there's no automated signal that they actually work together end-to-end. This workflow provides that signal.

Each cell installs the matrix-pinned versions explicitly, then installs momentfm from source, then runs the existing pytest suite (no existing tests are touched). Green CI on the frontier cell is the prerequisite for cutting `v0.1.5` to PyPI — see #84.

Files changed: `.github/workflows/ci.yml` (new, 71 lines).