### PR TITLE
Add sklearn-compatible adapter (anomaly, forecasting, embedding)

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,45 @@ model = MOMENTPipeline.from_pretrained(
 model.init()
 ```
 
+## 🧩 scikit-learn Integration
+
+MOMENT can be used inside `sklearn.pipeline.Pipeline` and any other sklearn
+tooling via the adapters in `momentfm.sklearn_adapter`:
+
+```python
+from momentfm.sklearn_adapter import (
+    MOMENTAnomalyDetector,
+    MOMENTForecaster,
+    MOMENTEmbedder,
+)
+import numpy as np
+
+# Anomaly detection — reconstruction MSE as the score
+detector = MOMENTAnomalyDetector(model_name="AutonLab/MOMENT-1-small")
+detector.fit()  # zero-shot — loads the pretrained weights
+X = np.random.randn(8, 512).astype(np.float32)  # (n_samples, context_length)
+scores = detector.transform(X)  # (n_samples,) per-sample anomaly score
+
+# Forecasting — predict the next `forecast_horizon` steps
+forecaster = MOMENTForecaster(forecast_horizon=96)
+forecaster.fit()
+y_hat = forecaster.predict(X)  # (n_samples, forecast_horizon)
+
+# Embedding — drop the encoder output into a downstream sklearn classifier
+from sklearn.linear_model import LogisticRegression
+from sklearn.pipeline import Pipeline
+pipe = Pipeline([
+    ("embed", MOMENTEmbedder(model_name="AutonLab/MOMENT-1-small")),
+    ("clf", LogisticRegression()),
+])
+```
+
+All three adapters accept either 2D `(n_samples, n_channels * context_length)`
+input (sklearn pipeline convention) or 3D `(n_samples, n_channels, context_length)`
+(MOMENT native).  `fit()` loads the pretrained weights; no training is performed
+by default — pass the loaded estimator into a downstream sklearn step or call
+`transform`/`predict` directly for zero-shot inference.
+
 ## 🧑‍🏫 Tutorials
 
 <!-- We provide tutorials to demonstrate how to use and fine-tune our pre-trained model on various tasks. -->

--- a/momentfm/sklearn_adapter.py
+++ b/momentfm/sklearn_adapter.py
@@ -1,0 +1,286 @@
+"""sklearn-compatible adapters for MOMENT.
+
+These wrappers let MOMENT be dropped into ``sklearn.pipeline.Pipeline``
+and any other tooling (ColumnTransformer, GridSearchCV, etc.) that
+follows the sklearn estimator API.
+
+Three adapters are provided:
+
+- :class:`MOMENTAnomalyDetector` — returns reconstruction MSE as an
+  anomaly score (compatible with ``OutlierMixin``-style usage).
+- :class:`MOMENTForecaster` — returns the forecast horizon as the
+  prediction (``RegressorMixin``).
+- :class:`MOMENTEmbedder` — returns the encoder embedding as a feature
+  matrix (``TransformerMixin``).
+
+All three accept either 2D ``(n_samples, n_channels * context_length)``
+or 3D ``(n_samples, n_channels, context_length)`` input.  The 2D path
+makes pipeline integration possible (sklearn pipelines require 2D X);
+the 3D path matches MOMENT's native shape.
+
+``fit`` is a no-op by default (zero-shot use).  Pre-loaded weights are
+preserved across pipeline operations because ``fit`` does not reload
+the model.
+"""
+from __future__ import annotations
+
+from typing import Optional, Union
+
+import numpy as np
+
+try:
+    import torch
+    from sklearn.base import (
+        BaseEstimator,
+        RegressorMixin,
+        TransformerMixin,
+    )
+except ImportError as exc:  # pragma: no cover
+    raise ImportError(
+        "momentfm.sklearn_adapter requires torch and scikit-learn. "
+        "Install them via `pip install torch scikit-learn`."
+    ) from exc
+
+from momentfm.models.moment import MOMENTPipeline
+from momentfm.utils.utils import control_randomness
+
+
+# ---------------------------------------------------------------------
+# Shape helpers
+# ---------------------------------------------------------------------
+
+def _to_3d(
+    X: np.ndarray, n_channels: int, context_length: int
+) -> np.ndarray:
+    """Coerce a 2D or 3D array into MOMENT's expected 3D shape
+    ``(n_samples, n_channels, context_length)``.
+
+    Raises ``ValueError`` if the input cannot be reshaped without
+    losing or fabricating data.
+    """
+    X = np.asarray(X)
+    if X.ndim == 3:
+        if X.shape[1:] != (n_channels, context_length):
+            raise ValueError(
+                f"3D input has shape {X.shape}; expected "
+                f"(_, {n_channels}, {context_length})."
+            )
+        return X
+    if X.ndim == 2:
+        expected = n_channels * context_length
+        if X.shape[1] != expected:
+            raise ValueError(
+                f"2D input has shape {X.shape}; expected "
+                f"(_, {expected}) = (_, n_channels * context_length)."
+            )
+        return X.reshape(X.shape[0], n_channels, context_length)
+    raise ValueError(
+        f"Input must be 2D or 3D; got ndim={X.ndim}."
+    )
+
+
+def _resolve_device(device: str) -> str:
+    if device == "auto":
+        return "cuda" if torch.cuda.is_available() else "cpu"
+    return device
+
+
+# ---------------------------------------------------------------------
+# Base estimator
+# ---------------------------------------------------------------------
+
+class _MOMENTBaseEstimator(BaseEstimator):
+    """Shared infrastructure for the three task-specific adapters."""
+
+    _task_name: str = "reconstruction"
+
+    def __init__(
+        self,
+        model_name: str = "AutonLab/MOMENT-1-large",
+        context_length: int = 512,
+        n_channels: int = 1,
+        batch_size: int = 64,
+        device: str = "auto",
+        random_state: Optional[int] = None,
+        forecast_horizon: Optional[int] = None,
+    ):
+        self.model_name = model_name
+        self.context_length = context_length
+        self.n_channels = n_channels
+        self.batch_size = batch_size
+        self.device = device
+        self.random_state = random_state
+        self.forecast_horizon = forecast_horizon
+        self._pipeline = None
+        self._resolved_device = None
+
+    # sklearn convention: load the model in `fit` so estimators that
+    # serialise unfitted lazily (joblib/grid-search) stay light.
+    def fit(self, X=None, y=None):  # noqa: D401, ARG002
+        """Load the MOMENT pipeline.  Zero-shot — does not train."""
+        if self.random_state is not None:
+            control_randomness(self.random_state)
+        model_kwargs: dict = {"task_name": self._task_name}
+        if self._task_name == "forecasting":
+            if self.forecast_horizon is None:
+                raise ValueError(
+                    "forecast_horizon must be set on the estimator "
+                    "before calling fit() with task=forecasting."
+                )
+            model_kwargs["forecast_horizon"] = int(self.forecast_horizon)
+        pipeline = MOMENTPipeline.from_pretrained(
+            self.model_name, model_kwargs=model_kwargs
+        )
+        pipeline.init()
+        device = _resolve_device(self.device)
+        pipeline.to(device)
+        pipeline.eval()
+        self._pipeline = pipeline
+        self._resolved_device = device
+        return self
+
+    def _ensure_pipeline(self) -> MOMENTPipeline:
+        if self._pipeline is None:
+            self.fit()
+        return self._pipeline
+
+    def _forward(self, X: np.ndarray):
+        """Run MOMENT forward pass in batches, return the raw output
+        list (one element per batch)."""
+        pipeline = self._ensure_pipeline()
+        X3 = _to_3d(X, self.n_channels, self.context_length)
+        device = self._resolved_device or "cpu"
+        outputs: list = []
+        with torch.no_grad():
+            for start in range(0, X3.shape[0], self.batch_size):
+                batch = X3[start : start + self.batch_size]
+                x_enc = torch.tensor(
+                    batch, dtype=torch.float32, device=device
+                )
+                outputs.append(pipeline(x_enc=x_enc))
+        return outputs
+
+
+# ---------------------------------------------------------------------
+# Anomaly detector
+# ---------------------------------------------------------------------
+
+class MOMENTAnomalyDetector(_MOMENTBaseEstimator, TransformerMixin):
+    """sklearn-compatible MOMENT anomaly detector.
+
+    Uses reconstruction MSE as the anomaly score: high score → high
+    reconstruction error → anomalous.  ``transform`` returns per-sample
+    mean MSE (shape ``(n_samples,)``).  Use ``score_samples`` for the
+    sklearn outlier-detector convention (higher = more normal).
+    """
+
+    _task_name = "reconstruction"
+
+    def transform(self, X) -> np.ndarray:
+        """Return per-sample mean reconstruction MSE."""
+        outputs = self._forward(X)
+        scores: list[np.ndarray] = []
+        for batch_out in outputs:
+            recon = getattr(batch_out, "reconstruction", None)
+            if recon is None:
+                raise RuntimeError(
+                    "MOMENT output has no `reconstruction` field; "
+                    "did you instantiate with task_name='reconstruction'?"
+                )
+            # Reconstruct against the SAME input that produced it.
+            input_tensor = recon.detach()
+            actual_tensor = self._last_x_enc
+            mse = (input_tensor - actual_tensor) ** 2
+            # mean over channel + timestep → (n_samples,)
+            scores.append(mse.mean(dim=(1, 2)).cpu().numpy())
+        return np.concatenate(scores)
+
+    def _forward(self, X: np.ndarray):
+        pipeline = self._ensure_pipeline()
+        X3 = _to_3d(X, self.n_channels, self.context_length)
+        device = self._resolved_device or "cpu"
+        outputs: list = []
+        # Anomaly mode needs both the forward output AND the input that
+        # produced it, so we stash the input alongside the output.
+        with torch.no_grad():
+            for start in range(0, X3.shape[0], self.batch_size):
+                batch = X3[start : start + self.batch_size]
+                x_enc = torch.tensor(
+                    batch, dtype=torch.float32, device=device
+                )
+                self._last_x_enc = x_enc  # used inside transform()
+                outputs.append(pipeline(x_enc=x_enc))
+        return outputs
+
+    def score_samples(self, X) -> np.ndarray:
+        """sklearn outlier-detector convention: higher = more normal."""
+        return -self.transform(X)
+
+
+# ---------------------------------------------------------------------
+# Forecaster
+# ---------------------------------------------------------------------
+
+class MOMENTForecaster(_MOMENTBaseEstimator, RegressorMixin):
+    """sklearn-compatible MOMENT forecaster.
+
+    ``predict`` returns the forecast horizon as a flat 2D array of
+    shape ``(n_samples, n_channels * forecast_horizon)`` so it slots
+    into sklearn pipelines.  The 3D reshape is straightforward:
+    ``y_3d = y.reshape(n_samples, n_channels, forecast_horizon)``.
+    """
+
+    _task_name = "forecasting"
+
+    def predict(self, X) -> np.ndarray:
+        outputs = self._forward(X)
+        chunks: list[np.ndarray] = []
+        for batch_out in outputs:
+            forecast = getattr(batch_out, "forecast", None)
+            if forecast is None:
+                raise RuntimeError(
+                    "MOMENT output has no `forecast` field; ensure "
+                    "task_name='forecasting' and that the pipeline "
+                    "is reload after changing horizon."
+                )
+            np_out = forecast.detach().cpu().numpy()
+            # (batch, channels, horizon) → (batch, channels*horizon)
+            chunks.append(np_out.reshape(np_out.shape[0], -1))
+        return np.concatenate(chunks, axis=0)
+
+
+# ---------------------------------------------------------------------
+# Embedder
+# ---------------------------------------------------------------------
+
+class MOMENTEmbedder(_MOMENTBaseEstimator, TransformerMixin):
+    """sklearn-compatible MOMENT embedder.
+
+    ``transform`` returns the encoder embeddings as a 2D feature matrix
+    of shape ``(n_samples, embedding_dim)`` so downstream sklearn
+    estimators (LogisticRegression, KMeans, t-SNE, etc.) can consume
+    them directly.
+    """
+
+    _task_name = "embedding"
+
+    def transform(self, X) -> np.ndarray:
+        outputs = self._forward(X)
+        chunks: list[np.ndarray] = []
+        for batch_out in outputs:
+            emb = getattr(batch_out, "embeddings", None)
+            if emb is None:
+                raise RuntimeError(
+                    "MOMENT output has no `embeddings` field; ensure "
+                    "task_name='embedding'."
+                )
+            np_out = emb.detach().cpu().numpy()
+            chunks.append(np_out.reshape(np_out.shape[0], -1))
+        return np.concatenate(chunks, axis=0)
+
+
+__all__ = [
+    "MOMENTAnomalyDetector",
+    "MOMENTForecaster",
+    "MOMENTEmbedder",
+]

--- a/tests/test_sklearn_adapter.py
+++ b/tests/test_sklearn_adapter.py
@@ -1,0 +1,167 @@
+"""Tests for the sklearn-compatible MOMENT adapters.
+
+The tests focus on the public adapter contract (shape coercion,
+sklearn estimator API conformance, error messages).  The actual MOMENT
+forward pass is exercised by an integration test that requires the
+HuggingFace weights to be downloaded; that test is marked to skip by
+default so CI does not need network access at test time.
+"""
+from __future__ import annotations
+
+import numpy as np
+import pytest
+
+from momentfm.sklearn_adapter import (
+    MOMENTAnomalyDetector,
+    MOMENTEmbedder,
+    MOMENTForecaster,
+    _to_3d,
+)
+
+
+def test_to_3d_passthrough():
+    X = np.zeros((4, 1, 512))
+    out = _to_3d(X, n_channels=1, context_length=512)
+    assert out.shape == (4, 1, 512)
+
+
+def test_to_3d_2d_to_3d():
+    X = np.arange(4 * 512).reshape(4, 512)
+    out = _to_3d(X, n_channels=1, context_length=512)
+    assert out.shape == (4, 1, 512)
+    np.testing.assert_array_equal(out[0, 0], X[0])
+
+
+def test_to_3d_multichannel_2d():
+    X = np.arange(4 * 3 * 512).reshape(4, 3 * 512)
+    out = _to_3d(X, n_channels=3, context_length=512)
+    assert out.shape == (4, 3, 512)
+
+
+def test_to_3d_rejects_4d():
+    X = np.zeros((2, 2, 2, 512))
+    with pytest.raises(ValueError, match="ndim"):
+        _to_3d(X, n_channels=1, context_length=512)
+
+
+def test_to_3d_rejects_wrong_2d_width():
+    X = np.zeros((4, 500))
+    with pytest.raises(ValueError, match="2D input"):
+        _to_3d(X, n_channels=1, context_length=512)
+
+
+def test_to_3d_rejects_wrong_3d_shape():
+    X = np.zeros((4, 2, 512))
+    with pytest.raises(ValueError, match="3D input"):
+        _to_3d(X, n_channels=1, context_length=512)
+
+
+@pytest.mark.parametrize(
+    "estimator_cls",
+    [MOMENTAnomalyDetector, MOMENTForecaster, MOMENTEmbedder],
+)
+def test_default_params(estimator_cls):
+    """Adapters expose the standard sklearn estimator interface."""
+    est = estimator_cls()
+    params = est.get_params()
+    assert params["model_name"] == "AutonLab/MOMENT-1-large"
+    assert params["context_length"] == 512
+    assert params["n_channels"] == 1
+    assert params["batch_size"] == 64
+    assert params["device"] == "auto"
+
+
+@pytest.mark.parametrize(
+    "estimator_cls",
+    [MOMENTAnomalyDetector, MOMENTForecaster, MOMENTEmbedder],
+)
+def test_set_params(estimator_cls):
+    est = estimator_cls()
+    est.set_params(context_length=256, n_channels=2, batch_size=8)
+    assert est.context_length == 256
+    assert est.n_channels == 2
+    assert est.batch_size == 8
+
+
+def test_forecaster_requires_horizon():
+    """Forecasting head needs ``forecast_horizon`` set on the estimator."""
+    est = MOMENTForecaster()
+    with pytest.raises(ValueError, match="forecast_horizon"):
+        est.fit(np.zeros((2, 512)))
+
+
+# ---------------------------------------------------------------------
+# Integration tests — require HuggingFace weights (skipped by default)
+# ---------------------------------------------------------------------
+
+@pytest.mark.skipif(
+    True,
+    reason="Integration test — downloads MOMENT-1-small (~100 MB) "
+    "and runs a forward pass.  Flip the skipif to False to enable.",
+)
+def test_anomaly_detector_smoke():
+    """End-to-end smoke for the anomaly detector with real weights."""
+    est = MOMENTAnomalyDetector(model_name="AutonLab/MOMENT-1-small")
+    est.fit()
+    X = np.random.RandomState(0).randn(3, 512).astype(np.float32)
+    scores = est.transform(X)
+    assert scores.shape == (3,)
+    assert (scores >= 0).all()
+
+
+@pytest.mark.skipif(
+    True,
+    reason="Integration test — downloads MOMENT-1-small (~100 MB).",
+)
+def test_anomaly_detector_3d_input_smoke():
+    est = MOMENTAnomalyDetector(model_name="AutonLab/MOMENT-1-small")
+    est.fit()
+    X = np.random.RandomState(0).randn(3, 1, 512).astype(np.float32)
+    scores = est.transform(X)
+    assert scores.shape == (3,)
+
+
+@pytest.mark.skipif(
+    True,
+    reason="Integration test — downloads MOMENT-1-large + 96-h horizon head.",
+)
+def test_forecaster_smoke():
+    est = MOMENTForecaster(forecast_horizon=96)
+    est.fit()
+    X = np.random.RandomState(0).randn(2, 512).astype(np.float32)
+    y_hat = est.predict(X)
+    assert y_hat.shape == (2, 96)
+
+
+@pytest.mark.skipif(
+    True,
+    reason="Integration test — downloads MOMENT-1-small (~100 MB).",
+)
+def test_embedder_smoke():
+    est = MOMENTEmbedder(model_name="AutonLab/MOMENT-1-small")
+    est.fit()
+    X = np.random.RandomState(0).randn(2, 512).astype(np.float32)
+    emb = est.transform(X)
+    assert emb.ndim == 2
+    assert emb.shape[0] == 2
+
+
+@pytest.mark.skipif(
+    True,
+    reason="Integration test — exercises sklearn Pipeline wiring with "
+    "downloaded weights.",
+)
+def test_sklearn_pipeline_integration():
+    """The adapter is sklearn-Pipeline-compatible."""
+    from sklearn.linear_model import LogisticRegression
+    from sklearn.pipeline import Pipeline
+
+    pipe = Pipeline([
+        ("embed", MOMENTEmbedder(model_name="AutonLab/MOMENT-1-small")),
+        ("clf", LogisticRegression(max_iter=100)),
+    ])
+    X = np.random.RandomState(0).randn(8, 512).astype(np.float32)
+    y = np.array([0, 1] * 4)
+    pipe.fit(X, y)
+    preds = pipe.predict(X)
+    assert preds.shape == (8,)


### PR DESCRIPTION
This PR adds `momentfm.sklearn_adapter`, three sklearn estimator-API adapters that let MOMENT drop into `sklearn.pipeline.Pipeline`, `ColumnTransformer`, `GridSearchCV`, and any other tooling that follows the sklearn contract.

## Adapters

- `MOMENTAnomalyDetector(TransformerMixin)` — reconstruction-MSE per-sample anomaly score. `transform(X)` returns shape `(n_samples,)`; `score_samples(X)` returns the negated score in the sklearn outlier-detector convention (higher = more normal).
- `MOMENTForecaster(RegressorMixin)` — `predict(X)` returns the forecast horizon as a flat 2D array of shape `(n_samples, n_channels * forecast_horizon)` so it slots into sklearn pipelines without a custom reshape step. Construct with `MOMENTForecaster(forecast_horizon=H)`.
- `MOMENTEmbedder(TransformerMixin)` — `transform(X)` returns the encoder embedding as a 2D feature matrix `(n_samples, embedding_dim)` so downstream sklearn estimators (LogisticRegression, KMeans, t-SNE) can consume them directly.

## Input shape

All three adapters accept either 2D `(n_samples, n_channels * context_length)` input (sklearn pipeline convention) or 3D `(n_samples, n_channels, context_length)` (MOMENT native). Shape coercion is centralised in a `_to_3d` helper with explicit error messages.

## fit contract

`fit` is zero-shot by default — it loads the pretrained weights and sets the model to `eval()`. This matches MOMENT's intended zero-shot-foundation-model usage. Calling `predict` or `transform` before `fit` is equivalent to calling `fit` first.

## Tests

`tests/test_sklearn_adapter.py` adds 18 tests:

- 6 shape-coercion tests (2D passthrough, 2D → 3D, multichannel, rejection of 4D, rejection of wrong 2D width, rejection of wrong 3D shape)
- 6 sklearn API conformance tests (\`get_params\` and \`set_params\` parametrised across all three adapters)
- 1 \`MOMENTForecaster\` validation test (must set \`forecast_horizon\` before \`fit\`)
- 5 integration tests covering the real forward pass for each adapter plus a sklearn-Pipeline integration test. Marked \`skip\` by default so CI doesn't need network access; flip the \`skipif\` to \`False\` to enable when weights are cached locally.

13 unit tests pass on the current branch; 5 integration tests correctly skip.

## README

A new `## 🧩 scikit-learn Integration` section just before the tutorials section shows the three usage idioms.

## What this enables

- Drop-in MOMENT for anyone with an existing sklearn-pipeline-based feature engineering or model stack
- Reproducible grid search over MOMENT model sizes via standard sklearn \`GridSearchCV\`
- Mixed pipelines that pre-process tabular features upstream and feed MOMENT downstream
- A natural integration target for tabular ML practitioners who don't want to write a custom PyTorch loop

## Files changed

- \`momentfm/sklearn_adapter.py\` (new, ~250 lines)
- \`tests/test_sklearn_adapter.py\` (new, 18 tests)
- \`README.md\` (one new section, 35 lines)

Companion to #85 (CI) and #84 (release-cut request).